### PR TITLE
Make 'Tag pills' handle hierarchical tags, and refactor slightly.

### DIFF
--- a/Snippets/Tag pills.md
+++ b/Snippets/Tag pills.md
@@ -2,29 +2,31 @@
 ```css
 /* Tag pills in edit mode - thanks to Whyl */
 /* to make rectangular tag pills w/ rounded corners change radii to 4 px */
-.CodeMirror-line span.cm-hashtag-begin {
+
+
+.CodeMirror-line span.cm-hashtag{
   background-color: var(--text-accent);
   color: white;
+  display: inline-block;
+  text-decoration: none !important;
+}
+
+
+.CodeMirror-line span.cm-hashtag-begin {
   border-top-left-radius:15px; /* change to 4px for rectangular pills */
   border-bottom-left-radius:15px; /* change to 4px for rectangular pills */
   padding-left:8px;
   border-right:none;
-  display: inline-block;
-  text-decoration: none !important;
 }
 
 .CodeMirror-line span.cm-hashtag-end {
-  background-color: var(--text-accent);
-  color: white;
   border-top-right-radius:15px; /* change to 4px for rectangular pills */
   border-bottom-right-radius:15px; /* change to 4px for rectangular pills */
   padding-right:8px;
   border-left:none;
-  display: inline-block;
-  text-decoration: none !important;
 }
 
-/* Tag pills in Preview mode
+/* Tag pills in Preview mode */
 .tag:not(.token) {
   border: none;
   color: white !important;


### PR DESCRIPTION
Fixes one important syntax error (the missing `*/` in `/* Tag pills in Preview mode */`) and correctly highlights tags of the format `#foo/bar`.  The previous version didn't highlight the `foo` section.

Minimal example with new version:

<img width="572" alt="Screen Shot 2021-03-17 at 9 35 45 PM" src="https://user-images.githubusercontent.com/288020/111569777-fd3e5000-8768-11eb-96c9-03fe7e91009e.png">
 