### PR TITLE
Develop

### DIFF
--- a/Snippets/Headers.md
+++ b/Snippets/Headers.md
@@ -362,3 +362,5 @@ If you need to have H1 headings capitalized in the note text, use:
     text-transform: uppercase;
 }
 ```
+
+# In Live Preview, show hashes

--- a/Snippets/Headers.md
+++ b/Snippets/Headers.md
@@ -363,4 +363,31 @@ If you need to have H1 headings capitalized in the note text, use:
 }
 ```
 
-# In Live Preview, show hashes
+In Live Preview, header hashes are hidden if the line is not active.
+Some people prefer to keep them visible to know what level header they are dealing with.
+The code below is courtesy of @NothingIsLost on the Discord forum.
+```css
+.cm-line > span.cm-header-1:not(.cm-formatting):before { content: "# "; }
+.cm-line.cm-active > span.cm-header-1 > span:not(.cm-selection):before { content: "# "; }
+.cm-line > span.cm-header-1 ~ span.cm-header-1:not(.cm-formatting):before { content: ""; }
+
+.cm-line > span.cm-header-2:not(.cm-formatting):before { content: "## "; }
+.cm-line.cm-active > span.cm-header-2 > span:not(.cm-selection):before { content: "## "; }
+.cm-line > span.cm-header-2 ~ span.cm-header-2:not(.cm-formatting):before { content: ""; }
+
+.cm-line > span.cm-header-3:not(.cm-formatting):before { content: "### "; }
+.cm-line.cm-active > span.cm-header-3 > span:not(.cm-selection):before { content: "### "; }
+.cm-line > span.cm-header-3 ~ span.cm-header-3:not(.cm-formatting):before { content: ""; }
+
+.cm-line > span.cm-header-4:not(.cm-formatting):before { content: "#### "; }
+.cm-line.cm-active > span.cm-header-4 > span:not(.cm-selection):before { content: "#### "; }
+.cm-line > span.cm-header-4 ~ span.cm-header-4:not(.cm-formatting):before { content: ""; }
+
+.cm-line > span.cm-header-5:not(.cm-formatting):before { content: "##### "; }
+.cm-line.cm-active > span.cm-header-5 > span:not(.cm-selection):before { content: "##### "; }
+.cm-line > span.cm-header-5 ~ span.cm-header-5:not(.cm-formatting):before { content: ""; }
+
+.cm-line > span.cm-header-6:not(.cm-formatting):before { content: "###### "; }
+.cm-line.cm-active > span.cm-header-6 > span:not(.cm-selection):before { content: "###### "; }
+.cm-line > span.cm-header-6 ~ span.cm-header-6:not(.cm-formatting):before { content: ""; }
+```

--- a/Snippets/Panes
+++ b/Snippets/Panes
@@ -1,4 +1,4 @@
-/* Masonry */
+# Masonry
 
 ```css
 div.workspace-split.mod-root > div.workspace-split.mod-vertical {

--- a/Snippets/Panes
+++ b/Snippets/Panes
@@ -1,6 +1,6 @@
-# Masonry
-
+# Panes
 ```css
+/* Masonry */
 div.workspace-split.mod-root > div.workspace-split.mod-vertical {
     overflow: auto;
 }

--- a/Snippets/Panes
+++ b/Snippets/Panes
@@ -1,4 +1,5 @@
-# Masonry
+/* Masonry */
+
 ```css
 div.workspace-split.mod-root > div.workspace-split.mod-vertical {
     overflow: auto;

--- a/Snippets/Panes
+++ b/Snippets/Panes
@@ -1,0 +1,14 @@
+# Masonry
+```css
+div.workspace-split.mod-root > div.workspace-split.mod-vertical {
+    overflow: auto;
+}
+div.workspace-split.mod-root div.workspace-split.mod-vertical > div.workspace-leaf {
+    min-width: 550px;
+}
+
+/* Horizontal Direction */
+div.workspace-split.mod-root > div.workspace-split.mod-horizontal > div.workspace-split.mod-vertical {
+    overflow: auto;
+}
+```


### PR DESCRIPTION
The sidenotes.css snippet does not work if the editor line length is not constrained (Options -> Editor -> readable line length). If you're working with that toggle off for any reason (for me, it's usually to accommodate a wide table) sidenotes will not show up properly. With the help of @ceciliamay I found this problem and she suggested an elegant fix: the modified code below automatically switches the sidebox position depending on whether the line length is set to "readable" so that it works in both states. 

```css
/* Sidenote in line with the main text */
aside {
    float: right;
    border: 1px solid lightgrey;
    padding: 8px;
    padding-top: 0px;
    position: relative;
    left: 10px;
    top: 5px;
    width: 300px; /*PB changed from 155px */
    box-shadow: 5px 10px 10px 2px rgba(119, 119, 119, 0.3);
    color: var(--text-accent);
    font-size: 14px;
    border-radius: 4px;
  }
  /* to put the sidenote in the right gutter, add this rule to the code above */
  /* margin-right: -20em;
  /*-Comments/Asides- source: ITS theme
  Syntax to be used in the note: <s class="aside-…">text</s>
  and replace … with show or hide or in */
  
  /*Show Aside when line width is set to "readable" */
    .markdown-source-view.is-readable-line-width .aside-show {
      text-decoration: unset;
      text-align: justify;
      font-weight: unset;
      float: right;
      position: relative;
      margin-right: 23em;
      margin-bottom: .2em;
      clear: right;
      width: 300px; /* PB changed from 400 */
      background-color: var(--background-primary-alt);
      padding: 0.2em 1em 1em 1em; /* PB changed from padding: 1em >> the 4 values */ 
      box-shadow: .3em .3em var(--interactive-accent);
      font-size: 14.5px; /* PB added this */
      border-radius: 4px; /* PB added this */
  }
  
 .aside-show {
	   /* For use when the line length is not shortened in the editor settings */
      text-decoration: unset;
      text-align: justify;
      font-weight: unset;
      float: right;
      position: relative;
      margin-right: 0em; /*ACB changed this so that the box is visible*/
      margin-bottom: .2em;
      clear: right;
      width: 300px; /* PB changed from 400 */
      background-color: var(--background-primary-alt);
      padding: 0.2em 1em 1em 1em; /* PB changed from padding: 1em >> the 4 values */ 
      box-shadow: .3em .3em var(--interactive-accent);
      font-size: 14.5px; /* PB added this */
      border-radius: 4px; /* PB added this */
  }
  
  /*Hide Aside and hover to reveal it; version for readable line length*/
.is-readable-line-width.aside-hide {
      text-decoration: unset;
      text-align: justify;
      color: transparent;
      font-weight: unset;
      float: right;
      position: relative;
      margin: .5em;
      margin-right: -1.8em;
      width: 1.5em;
      height: 1.5em;
      clear: right;
      overflow: hidden;
      background-color: var(--background-primary-alt);
      color: transparent;
  }
  
  .is-readable-line-width.aside-hide{
/* Again, this is a variant for when the text fills all available space*/
      text-decoration: unset;
      text-align: justify;
      color: transparent;
      font-weight: unset;
      float: right;
      position: relative;
      margin: .5em;
      margin-right: 0em; /*ACB hack — see above */
      width: 1.5em;
      height: 1.5em;
      clear: right;
      overflow: hidden;
      background-color: var(--background-primary-alt);
      color: transparent;
  }
  .aside-hide:before {
      display: block;
      border-bottom: 2px solid var(--background-modifier-border);
      content: "🗨 ";
      color: red; /*ACB changed this for visibility in a light theme*/
      text-shadow: 0 0 0 var(--interactive-accent);
      font-size: 20px; /*ACB change for visibility*/
      padding-top: .1em;
      padding-left: .3em;
  }
  .aside-hide:hover {
      white-space: normal;
      text-overflow: unset;
      color: unset;
      width: 300px; /* PB changed from 400 */
      height: unset;
      background-color: var(--background-primary-alt);
      padding: 1em;
      padding-top: .5em;
      z-index: 3;
      /*box-shadow: .5em .5em var(--outer-bar);*/
      border-right: 2px solid var(--interactive-accent);
      font-size: 14.5px; /* PB added this */
      border-radius: 4px; /* PB added this */
  }
  
  /*Aside Inside the Note*/
  .aside-in {
      text-decoration: none !important;
      text-align: justify;
      font-weight: unset;
      float: right;
      position: relative;
      margin-bottom: .2em;
      clear: right;
      width: 18em;
      background-color: var(--background-primary-alt);
      padding: 1em;
      box-shadow: .3em .3em var(--interactive-accent);
      z-index: 3;
      font-size: 14.5px; /* PB added this */
      border-radius: 4px; /* PB added this */
  }
  
  .aside-in .internal-embed.is-loaded:not(.image-embed),
  .aside-in .markdown-embed {
      width:100%;
  }
  /*Shrink Scrollbar*/
  .aside > ::-webkit-scrollbar {
      width: 5px;
  }
```