### PR TITLE
Add a snippet for static caret in Vim mode

### DIFF
--- a/Snippets/Vim Static Caret.md
+++ b/Snippets/Vim Static Caret.md
@@ -1,4 +1,4 @@
-# VimStaticCaret
+# Vim Static Caret
 
 Changes the Vim caret from a blinking one to a static one in the editor to reflect a more realistic Vim experience.
 

--- a/Snippets/VimStaticCaret.md
+++ b/Snippets/VimStaticCaret.md
@@ -1,0 +1,17 @@
+# VimStaticCaret
+
+Changes the Vim caret from a blinking one to a static one in the editor to reflect a more realistic Vim experience.
+
+```css
+.cm-fat-cursor .CodeMirror-cursor {
+  visibility: visible !important;
+}
+
+.cm-animate-fat-cursor {
+  animation: none;
+}
+
+div.CodeMirror-cursors, div.CodeMirror-dragcursors, div.CodeMirror-secondarycursor {
+  visibility: visible !important;
+}
+```


### PR DESCRIPTION
Instead of a blinking animated one, this one strips out the fanciness and we are left with the beautiful look of a static caret.