### PR TITLE
make mermaid diagrams resizable with css code snippets

### DIFF
--- a/Snippets/Resizable Mermaid.md
+++ b/Snippets/Resizable Mermaid.md
@@ -1,0 +1,32 @@
+# Resizable Mermaid Diagrams
+
+```css
+svg[id^="m"][width][height][viewBox] {
+    max-width: 95%;
+    max-height: 95%;
+}
+
+div.mermaid {
+    margin-left: 0 !important;
+    text-align: center;
+    resize:both;
+    overflow:auto;
+    margin-bottom: 2px;
+    position:relative;
+    max-height: 600px;
+    max-width: 100%;
+}
+
+div.mermaid::after {
+    content:'';
+    display:block;
+    width:10px;
+    height:10px;
+    background-color:yellowgreen;
+    position:absolute;
+    right:0;
+    bottom:0;
+}
+```
+
+![](https://raw.githubusercontent.com/tctco/ImgHosting/master/mermaidResize.gif)


### PR DESCRIPTION
Though I'm not an expert in css, I've done some research to make mermaid diagrams resizable and the code snippet works well for me. It could help users zoom in/out mermaid diagrams to some extent :)

[Here is the original FR: Ability to resize and align mermaid diagrams](https://forum.obsidian.md/t/ability-to-resize-and-align-mermaid-diagrams/7019/22)